### PR TITLE
Refresh the apt cache before trying to install anything

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,3 +8,4 @@ version '0.1.0'
 
 depends 'jenkins', '2.3.1'
 depends 'git', '4.2.2'
+depends 'apt', '2.7.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,6 +7,10 @@
 # Copyright (c) 2015 Torben Knerr
 #
 
+# refresh apt cache
+include_recipe 'apt'
+
+# install jenkins
 node.set['git']['version'] = '1.9.1'
 include_recipe 'git'
 
@@ -16,7 +20,6 @@ node.set['jenkins']['master']['install_method'] = 'package'
 node.set['jenkins']['master']['repository'] = 'http://pkg.jenkins-ci.org/debian-stable'
 node.set['jenkins']['master']['repository_key'] = 'http://pkg.jenkins-ci.org/debian-stable/jenkins-ci.org.key'
 node.set['jenkins']['master']['version'] = '1.609.1'
-
 include_recipe 'jenkins::master'
 
 # install plugins


### PR DESCRIPTION
...otherwise the installation of any packages (e.g. Git) is doomed to fail

E.g. just happened:
```
...
==> jenkins:
==> jenkins: ================================================================================
==> jenkins: Error executing action `install` on resource 'apt_package[default :create git]'
==> jenkins: ================================================================================
==> jenkins:
==> jenkins:
==> jenkins: Mixlib::ShellOut::ShellCommandFailed
==> jenkins:
==> jenkins: ------------------------------------
==> jenkins: Expected process to exit with [0], but received '100'
==> jenkins: ---- Begin output of apt-get -q -y install git=1:1.9.1-1 ----
==> jenkins: STDOUT: Reading package lists...
==> jenkins: Building dependency tree...
==> jenkins: Reading state information...
==> jenkins: The following extra packages will be installed:
==> jenkins:   git-man liberror-perl patch
==> jenkins: Suggested packages:
==> jenkins:   git-daemon-run git-daemon-sysvinit git-doc git-el git-email git-gui gitk
==> jenkins:   gitweb git-arch git-bzr git-cvs git-mediawiki git-svn diffutils-doc
==> jenkins: The following NEW packages will be installed:
==> jenkins:   git git-man liberror-perl patch
==> jenkins: 0 upgraded, 4 newly installed, 0 to remove and 0 not upgraded.
==> jenkins: Need to get 3338 kB/3359 kB of archives.
==> jenkins: After this operation, 21.8 MB of additional disk space will be used.
==> jenkins: Get:1 http://us.archive.ubuntu.com/ubuntu/ trusty/main git-man all 1:1.9.1-1 [698 kB]
==> jenkins: Get:2 http://us.archive.ubuntu.com/ubuntu/ trusty/main git amd64 1:1.9.1-1 [2555 kB]
==> jenkins: Err http://us.archive.ubuntu.com/ubuntu/ trusty-updates/main patch amd64 2.7.1-4ubuntu1
==> jenkins:   404  Not Found [IP: 91.189.91.24 80]
==> jenkins: Fetched 3253 kB in 47s (68.3 kB/s)
==> jenkins: STDERR: E: Failed to fetch http://us.archive.ubuntu.com/ubuntu/pool/main/p/patch/patch_2.7.1-4ubuntu1_amd64.deb  404  Not Found [IP: 91.189.91.24 80]
==> jenkins:
==> jenkins: E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
==> jenkins: ---- End output of apt-get -q -y install git=1:1.9.1-1 ----
==> jenkins: Ran apt-get -q -y install git=1:1.9.1-1 returned 100
...
```