### PR TITLE
remove the Berksfile.lock from .gitignore and add it to version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .vagrant
-Berksfile.lock
 *~
 *#
 .#*

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,0 +1,17 @@
+DEPENDENCIES
+  jenkins-simple-app
+    path: .
+    metadata: true
+
+GRAPH
+  apt (2.7.0)
+  jenkins (2.3.1)
+    apt (~> 2.0)
+    runit (~> 1.5)
+    yum (~> 3.0)
+  jenkins-simple-app (0.1.0)
+    jenkins (= 2.3.1)
+  packagecloud (0.0.18)
+  runit (1.6.0)
+    packagecloud (>= 0.0.0)
+  yum (3.6.0)


### PR DESCRIPTION
This PR puts the `Berksfile.lock` under version control.

Why?

Because this is a quite "top level" cookbook (i.e. only downstream dependencies, but nobody depending on us) for which we want to lock the whole dependency graph to keep it reproducible.

If we wouldn't put the `Berksfile.lock` under version control here, we might end up with updated transitive dependencies without having us control over it.

/cc @kimo @MaltePir @damphyr 