### PR TITLE
Switch to kitchen-vagrant driver with docker provider for CI build

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,18 +1,29 @@
+<%
+def box_for_provider(distro)
+  case ENV.fetch('VAGRANT_DEFAULT_PROVIDER', 'virtualbox')
+    when 'virtualbox' then "bento/#{distro}"
+    when 'docker' then "tknerr/baseimage-#{distro}"
+    else raise 'unsupported provider!'
+  end
+end
+%>
 ---
 driver:
   name: vagrant
 
-driver_config:
-  network:
-    - ["forwarded_port", {guest: 8080, host: 8080}]
-
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.3.0
+  require_chef_omnibus: 12.4.1
   chef_omnibus_install_options: -d /tmp/vagrant-cache/vagrant_omnibus
+  client_rb:
+    add_formatter: doc
 
 platforms:
-  - name: ubuntu-14.04
+- name: ubuntu-14.04
+  driver_config:
+    box: <%= box_for_provider('ubuntu-14.04') %>
+    network:
+      - ["forwarded_port", {guest: 8080, host: 8080}]
 
 suites:
   - name: default

--- a/circle.yml
+++ b/circle.yml
@@ -4,9 +4,14 @@ machine:
   ruby:
     version: 2.1.5
   environment:
-    KITCHEN_LOCAL_YAML: .kitchen.docker.yml
+    VAGRANT_DEFAULT_PROVIDER: docker
 
 dependencies:
+  cache_directories:
+    - ~/.vagrant.d
+  pre:
+    - wget https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.4_x86_64.deb
+    - sudo dpkg -i vagrant_1.7.4_x86_64.deb
   override:
     - bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3:
         timeout: 900


### PR DESCRIPTION
This PR 

 * makes the `.kitchen.yml` usable with either vagrant/virtualbox or vagrant/docker provider
 * swtiches the CircleCI build to using docker via vagrant instead of plain docker (rationale: for development we are rather using vagrant/docker so we can use of vagrant-cachier, and the CI build process should be aligned to that)