### PR TITLE
Extract helper methods and put them under "libraries"

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,15 @@
+
+#
+# returns true if the given port is open, false otherwise
+#
+def port_open?(port)
+  listen_ports = IO.popen('netstat -lnt').entries
+  listen_ports.select { |e| e.split[3] =~ /:#{port}$/ }.any?
+end
+
+#
+# returns the Net::HTTP response for doing a GET on the given url
+#
+def http_get(url)
+  Chef::REST::RESTRequest.new(:GET, URI.parse(url), nil).call
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -66,13 +66,12 @@ end
 # block until jenkins is up & ready
 ruby_block 'block_until_operational' do
   block do
-    until IO.popen('netstat -lnt').entries.select { |e| e.split[3] =~ /:8080$/ }.size == 1
+    until port_open? '8080'
       Chef::Log.debug 'service[jenkins] not listening on port 8080'
       sleep 1
     end
     loop do
-      url = URI.parse('http://localhost:8080/job/SeedJob/config.xml')
-      res = Chef::REST::RESTRequest.new(:GET, url, nil).call
+      res = http_get('http://localhost:8080/job/SeedJob/config.xml')
       break if res.is_a?(Net::HTTPSuccess) || res.is_a?(Net::HTTPNotFound)
       Chef::Log.debug "service[jenkins] not responding OK to GET /job/SeedJob/config.xml #{res.inspect}"
       sleep 1

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -16,9 +16,9 @@ describe 'jenkins-simple-app::default' do
     expect(port(8080)).to be_listening
   end
 
-  it 'installs jenkins version 1.609.1' do
+  it 'installs jenkins version 1.609.3' do
     cmd = command('wget -qO- localhost:8080')
-    expect(cmd.stdout).to include 'Jenkins ver. 1.609.1'
+    expect(cmd.stdout).to include 'Jenkins ver. 1.609.3'
   end
 
   it 'installs some jenkins plugins' do

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -16,7 +16,7 @@ describe 'jenkins-simple-app::default' do
     expect(port(8080)).to be_listening
   end
 
-  it 'installs jenkins version 1.609.3' do
+  it 'runs the expected version of jenkins' do
     cmd = command('wget -qO- localhost:8080')
     expect(cmd.stdout).to include 'Jenkins ver. 1.609.3'
   end
@@ -41,12 +41,12 @@ describe 'jenkins-simple-app::default' do
     expect(response).to include "<shortName>#{plugin}</shortName><version>#{version}</version>"
   end
 
-  it 'git version installed' do
+  it 'installs git at version 1.9.1' do
     expect(command('git --version').stdout).to include 'git version 1.9.1'
   end
 
-  it 'jenkins package installed' do
-    expect(package('jenkins')).to be_installed.with_version('1.609.1')
+  it 'installs jenkins package at version 1.609.3' do
+    expect(package('jenkins')).to be_installed.with_version('1.609.3')
   end
 
   it 'created the seed job in jenkins' do


### PR DESCRIPTION
Extract two helper methods and put them under the "libraries" directory.

First, this reduces complexity and should make our CircleCI build go green again (rubocop line length check).

Second, the helper methods could now be reused from other recipes.